### PR TITLE
fix: update dependencies installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk --no-cache add build-base git python3 python3-dev py3-pip jq
 
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 
-RUN python3 -m pip install semgrep
+RUN python3 -m pip install --ignore-installed semgrep
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Fix for:
```
ERROR: Cannot uninstall 'packaging'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
```